### PR TITLE
Automatically Load Game Cards on Initial Page Load

### DIFF
--- a/game-ranking.client/src/components/RankItems.jsx
+++ b/game-ranking.client/src/components/RankItems.jsx
@@ -8,7 +8,7 @@ const RankItems = () => {
   const [items, setItems] = useState([]);
   const dataType = 1;
 
-  const [reload, setReload] = useState(false);
+  const [reload, setReload] = useState(true);
 
   const localStorageKey = "rpg";
 


### PR DESCRIPTION
## What does this PR do?
This pull request updates the behavior of the page to automatically fetch and load game cards from the server when the page is initially loaded. Previously, the game cards were only fetched upon clicking the reload button.


## Before
https://github.com/e-choness/game-ranking-app/assets/68678264/fca6b039-d420-4d22-b905-93a9d2ed641a

## After
https://github.com/e-choness/game-ranking-app/assets/68678264/e4bf5c7c-bdc2-48f8-89f4-0fd39d5eb12a

